### PR TITLE
Refactor

### DIFF
--- a/app.py
+++ b/app.py
@@ -537,7 +537,7 @@ def get_decline_view(sess, game_id):
 
     game_state = GameState.from_json(animation_frame.game_state)
 
-    game_state_json = game_state.to_json(include_city_civ_details=True)
+    game_state_json = game_state.to_json()
 
     return jsonify({
         'game_state': game_state_json,

--- a/camp.py
+++ b/camp.py
@@ -5,6 +5,7 @@ import random
 from civ import Civ
 
 from typing import TYPE_CHECKING
+from map_object import MapObject
 from settings import CAMP_CLEAR_CITY_POWER_REWARD, CAMP_CLEAR_VP_REWARD, STRICT_MODE
 from unit import Unit
 
@@ -28,28 +29,20 @@ def random_unit_by_age(advancement_level) -> UnitTemplate:
     else:
         return random_unit_by_age(advancement_level - 1)
 
-class Camp:
+class Camp(MapObject):
     def __init__(self, civ: Civ, advancement_level=0, unit: UnitTemplate | None = None):
         # civ actually can be None very briefly before GameState.from_json() is done, 
         # but I don't want to tell the type-checker so we don't have to put a million asserts everywhere
 
+        super().__init__()
         self.id = generate_unique_id()
         self.under_siege_by_civ: Optional[Civ] = None
-        self._hex: Optional['Hex'] = None        
         self.civ: Civ = civ
         self.civ_id: str = civ.id if civ else None  # type: ignore
         self.target: Optional['Hex'] = None
         if STRICT_MODE:
             assert unit is None or advancement_level == 0, f"Only set one of unit and advancement_level"
         self.unit: UnitTemplate = unit or random_unit_by_age(advancement_level)
-
-    @property
-    def hex(self) -> 'Hex':
-        assert self._hex is not None
-        return self._hex
-    
-    def set_hex(self, hex: 'Hex'):
-        self._hex = hex
 
     def update_nearby_hexes_visibility(self, game_state: 'GameState', short_sighted: bool = False) -> None:
         if short_sighted:

--- a/camp.py
+++ b/camp.py
@@ -92,7 +92,7 @@ class Camp:
 
     def spawn_unit_on_hex(self, sess, game_state: 'GameState', unit_template: UnitTemplate, hex: 'Hex') -> None:
         unit = Unit(unit_template, self.civ)
-        unit.hex = hex
+        unit.set_hex(hex)
         hex.units.append(unit)
         game_state.units.append(unit)
         if self.hex.coords != unit.hex.coords:

--- a/city.py
+++ b/city.py
@@ -95,7 +95,7 @@ class City:
         assert self._hex is not None
         return self._hex
     
-    def set_hex(self, hex: 'Hex | None'):
+    def set_hex(self, hex: 'Hex'):
         self._hex = hex
 
     def has_building(self, template: BuildingTemplate | UnitTemplate | WonderTemplate) -> bool:

--- a/city.py
+++ b/city.py
@@ -6,7 +6,7 @@ from building_templates_list import BUILDINGS
 from civ_template import CivTemplate
 from civ import Civ
 from camp import Camp
-from map_object import MapObject
+from map_object_spawner import MapObjectSpawner
 from settings import GOD_MODE
 from terrain_templates_list import TERRAINS
 from terrain_template import TerrainTemplate
@@ -31,7 +31,7 @@ TRADE_HUB_CITY_POWER_PER_TURN = 20
 
 _DEVELOPMENT_VPS_STR = f"Development ({DEVELOP_VPS} each)"
 
-class City(MapObject):
+class City(MapObjectSpawner):
     def __init__(self, name: str, civ: Civ | None = None, id: Optional[str] = None, hex: 'Hex | None' = None):
         super().__init__(civ, hex)
         self.id = id or generate_unique_id()
@@ -47,7 +47,6 @@ class City(MapObject):
         self.rural_slots = 1
         self.urban_slots = 1
         self.military_slots = 1
-        self.under_siege_by_civ: Optional[Civ] = None
         self.buildings_queue: list[QueueEntry] = []
         self.buildings: list[Building] = []
         self.unit_buildings: list[UnitBuilding] = [UnitBuilding(UNITS.WARRIOR)]
@@ -1077,7 +1076,6 @@ class City(MapObject):
             "rural_slots": self.rural_slots,
             "urban_slots": self.urban_slots,
             "military_slots": self.military_slots,
-            "under_siege_by_civ_id": self.under_siege_by_civ.id if self.under_siege_by_civ else None,
             "hex": self.hex.coords,
             "icon_unit_name": sorted(self.active_unit_buildings, key=lambda u: u.template.advancement_level(), reverse=True)[0].template.name if len(self.active_unit_buildings) > 0 else None,
             "buildings_queue": [building.to_json() for building in self.buildings_queue],
@@ -1145,7 +1143,6 @@ class City(MapObject):
         city.rural_slots = json["rural_slots"]
         city.urban_slots = json["urban_slots"]
         city.military_slots = json["military_slots"]
-        city.under_siege_by_civ = json["under_siege_by_civ_id"]
         city.capital = json["capital"]
         city.buildings_queue = [QueueEntry.from_json(entry) for entry in json["buildings_queue"]]
         city.available_buildings_to_descriptions = (json.get("available_buildings_to_descriptions") or {}).copy()
@@ -1171,10 +1168,6 @@ class City(MapObject):
         city.seen_by_players = set(json["seen_by_players"])
 
         return city
-
-    def from_json_postprocess(self, game_state: 'GameState'):
-        super().from_json_postprocess(game_state)
-        self.under_siege_by_civ = game_state.civs_by_id[self.under_siege_by_civ] if self.under_siege_by_civ else None  # type: ignore
 
 CITY_NAMES = {
     "Miami",

--- a/city.py
+++ b/city.py
@@ -602,7 +602,7 @@ class City:
         if best_hex is not None:
             return self.spawn_unit_on_hex(game_state, unit, best_hex, bonus_strength, stack_size=stack_size)
 
-        potential_units_to_reinforce = [u for hex in spawn_hex.get_neighbors(game_state.hexes, include_self=True) for u in hex.units if u.civ == self.civ and u.template == unit and u.hex and u.strength == unit.strength + bonus_strength]  
+        potential_units_to_reinforce = [u for hex in spawn_hex.get_neighbors(game_state.hexes, include_self=True) for u in hex.units if u.civ == self.civ and u.template == unit and u.strength == unit.strength + bonus_strength]  
 
         if len(potential_units_to_reinforce) > 0:
             best_unit_to_reinforce = min(potential_units_to_reinforce, key=lambda u: (
@@ -671,7 +671,7 @@ class City:
     def spawn_unit_on_hex(self, game_state: 'GameState', unit_template: UnitTemplate, hex: 'Hex', bonus_strength: int, stack_size=1) -> Unit | None:
         unit = Unit(unit_template, self.civ)
         unit.health *= stack_size
-        unit.hex = hex
+        unit.set_hex(hex)
         hex.units.append(unit)
         game_state.units.append(unit)
         unit.strength += bonus_strength

--- a/city.py
+++ b/city.py
@@ -6,6 +6,7 @@ from building_templates_list import BUILDINGS
 from civ_template import CivTemplate
 from civ import Civ
 from camp import Camp
+from map_object import MapObject
 from settings import GOD_MODE
 from terrain_templates_list import TERRAINS
 from terrain_template import TerrainTemplate
@@ -30,11 +31,11 @@ TRADE_HUB_CITY_POWER_PER_TURN = 20
 
 _DEVELOPMENT_VPS_STR = f"Development ({DEVELOP_VPS} each)"
 
-class City:
+class City(MapObject):
     def __init__(self, civ: Civ, name: str, id: Optional[str] = None):
         # civ actually can be None very briefly before GameState.from_json() is done, 
         # but I don't want to tell the type-checker so we don't have to put a million asserts everywhere
-
+        super().__init__()
         self.id = id or generate_unique_id()
         self.civ: Civ = civ
         self.civ_id: str = civ.id if civ else None  # type: ignore
@@ -51,7 +52,6 @@ class City:
         self.urban_slots = 1
         self.military_slots = 1
         self.under_siege_by_civ: Optional[Civ] = None
-        self._hex: Optional['Hex'] = None
         self.buildings_queue: list[QueueEntry] = []
         self.buildings: list[Building] = []
         self.unit_buildings: list[UnitBuilding] = [UnitBuilding(UNITS.WARRIOR)]
@@ -89,14 +89,6 @@ class City:
     
     def __hash__(self):
         return hash(self.id)
-
-    @property
-    def hex(self) -> 'Hex':
-        assert self._hex is not None
-        return self._hex
-    
-    def set_hex(self, hex: 'Hex'):
-        self._hex = hex
 
     def has_building(self, template: BuildingTemplate | UnitTemplate | WonderTemplate) -> bool:
         if isinstance(template, UnitTemplate):
@@ -431,7 +423,7 @@ class City:
                 self.terrains_dict[hex.terrain] += 1
 
     def _refresh_available_buildings_and_units(self, game_state):
-        if self.civ is None or self._hex is None:
+        if self.civ is None:
             return
         self.available_units = sorted([unit for unit in UNITS.all() if unit.building_name is None or self.has_production_building_for_unit(unit)])
         

--- a/civ.py
+++ b/civ.py
@@ -374,20 +374,17 @@ class Civ:
             enemy_cities: list[City] = [city for city in game_state.cities_by_id.values() if city.civ.id != self.id]
             vandetta_cities: list[City] = [city for city in enemy_cities if city.civ.id == self.vandetta_civ_id]
             if len(vandetta_cities) > 0:
-                possible_target_hexes: list[Hex | None] = [city.hex for city in vandetta_cities]
+                possible_target_hexes: list[Hex] = [city.hex for city in vandetta_cities]
             else:
-                possible_target_hexes: list[Hex | None] = [*[city.hex for city in enemy_cities], *[camp.hex for camp in game_state.camps]]
+                possible_target_hexes: list[Hex] = [*[city.hex for city in enemy_cities], *[camp.hex for camp in game_state.camps]]
 
-            # These all aren't None, but we've got to make the type checker happy
-            possible_target_hexes_filtered: list[Hex] = [hex for hex in possible_target_hexes if hex is not None]
+            random.shuffle(possible_target_hexes)
 
-            random.shuffle(possible_target_hexes_filtered)
-
-            if len(possible_target_hexes_filtered) > 0:
-                self.target1 = possible_target_hexes_filtered[0]
+            if len(possible_target_hexes) > 0:
+                self.target1 = possible_target_hexes[0]
                 self.target1_coords = self.target1.coords
-            if len(possible_target_hexes_filtered) > 1:
-                self.target2 = possible_target_hexes_filtered[1]
+            if len(possible_target_hexes) > 1:
+                self.target2 = possible_target_hexes[1]
                 self.target2_coords = self.target2.coords
 
         if self.researching_tech is None:

--- a/civ.py
+++ b/civ.py
@@ -317,7 +317,6 @@ class Civ:
         
         option_total_yields: dict[str, float] = {}
         for city in game_state.cities_by_id.values():
-            assert city.hex is not None, "Unregistered city found!"
             if city.civ_to_revolt_into is None:
                 continue
 

--- a/effects_list.py
+++ b/effects_list.py
@@ -171,9 +171,9 @@ class RecruitBarbariansEffect(CityTargetEffect):
     def apply(self, city: 'City', game_state: 'GameState'):
         for hex in city.hex.get_hexes_within_range_expensive(game_state.hexes, self.range):
             if len(hex.units) > 0 and hex.units[0].civ == game_state.barbarians:
-                hex.units[0].civ = city.civ
+                hex.units[0].update_civ(city.civ)
             if hex.camp is not None and hex.camp.civ == game_state.barbarians:
-                hex.camp.civ = city.civ
+                hex.camp.update_civ(city.civ)
 
 class PointsEffect(CityTargetEffect):
     def __init__(self, calculate_points: Callable[['City', 'GameState'], int], description: str, label: str) -> None:

--- a/effects_list.py
+++ b/effects_list.py
@@ -153,7 +153,6 @@ class FreeNearbyCityEffect(CityTargetEffect):
                 if neighbor.city is not None:
                     return False
             return True
-        assert city.hex is not None
         for hex in city.hex.get_distance_2_hexes(game_state.hexes):
             if valid_spot(hex):
                 city.civ.city_power += 100
@@ -170,7 +169,6 @@ class RecruitBarbariansEffect(CityTargetEffect):
         return f"Recruit all barbarians within {self.range} tiles (including camps)"
     
     def apply(self, city: 'City', game_state: 'GameState'):
-        assert city.hex is not None
         for hex in city.hex.get_hexes_within_range_expensive(game_state.hexes, self.range):
             if len(hex.units) > 0 and hex.units[0].civ == game_state.barbarians:
                 hex.units[0].civ = city.civ

--- a/frontend/src/GamePage.js
+++ b/frontend/src/GamePage.js
@@ -427,6 +427,7 @@ export default function GamePage() {
     const techChoices = myCiv?.current_tech_choices;
 
     const civsById = gameState?.civs_by_id;
+    const declineViewCivsById = declineViewGameState?.civs_by_id;
 
     const myCities = Object.values(mainGameState?.cities_by_id || {}).filter(city => civsById?.[city.civ_id]?.game_player?.player_num === myGamePlayer?.player_num);
     const myTerritoryCapitals = myCities.filter(city => city.territory_parent_coords === null);
@@ -3135,6 +3136,7 @@ export default function GamePage() {
                         declineViewGameState={declineViewGameState}
                         declineOptionsView={declineOptionsView}
                         civsById={civsById}
+                        declineViewCivsById={declineViewCivsById}
                     />}
                     {selectedCity && <CityDetailWindow 
                         gameState={gameState}

--- a/frontend/src/UpperRightDisplay.js
+++ b/frontend/src/UpperRightDisplay.js
@@ -115,17 +115,19 @@ const WonderListDisplay = ({ wonders_by_age, game_age, built_wonders, cost_by_ag
     </CivDetailPanel>
 }
 
-const DeclineOptionRow = ({ city, isMyCity, myCiv, setDeclineOptionsView, templates, centerMap, setHoveredCiv, setHoveredUnit, setHoveredBuilding, setSelectedCity, civsById}) => {
+const DeclineOptionRow = ({ city, isMyCity, myCiv, setDeclineOptionsView, templates, centerMap, setHoveredCiv, setHoveredUnit, setHoveredBuilding, setSelectedCity, declineViewCivsById}) => {
+    const civ = declineViewCivsById[city.civ_id];
+    const civTemplate = templates.CIVS[civ.name];
     return <div className="decline-option-row"
         style={{
-            backgroundColor: templates.CIVS[city.civ.name]?.primary_color, 
-            borderColor: templates.CIVS[city.civ.name]?.secondary_color}}
+            backgroundColor: civTemplate.primary_color, 
+            borderColor: civTemplate.secondary_color}}
         onClick = {() => {
             setDeclineOptionsView(true);
             setSelectedCity(city);
             centerMap(city.hex);
         }}
-        onMouseEnter={() => setHoveredCiv(templates.CIVS[city.civ.name])}
+        onMouseEnter={() => setHoveredCiv(civ)}
         onMouseLeave={() => setHoveredCiv(null)}
         >
         <div className="revolt-cities-row">
@@ -187,7 +189,7 @@ const DeclineOptionRow = ({ city, isMyCity, myCiv, setDeclineOptionsView, templa
 const CivVitalityDisplay = ({ playerNum, myCiv, turnNum, centerMap, 
     setDeclineOptionsView, declineViewGameState, mainGameState, declineOptionsView, 
     templates,
-    setSelectedCity, setHoveredCiv, setHoveredUnit, setHoveredBuilding, civsById}) => {
+    setSelectedCity, setHoveredCiv, setHoveredUnit, setHoveredBuilding, declineViewCivsById}) => {
     const citiesReadyForRevolt = Object.values(declineViewGameState?.cities_by_id || {}).filter(city => city.is_decline_view_option);
     const unhappinessThreshold = mainGameState?.unhappiness_threshold
     // Max of all other players' scores
@@ -214,7 +216,7 @@ const CivVitalityDisplay = ({ playerNum, myCiv, turnNum, centerMap,
                     return <DeclineOptionRow key={city.id} city={city} isMyCity={isMyCity} myCiv={myCiv} setDeclineOptionsView={setDeclineOptionsView} centerMap={centerMap}
                         templates={templates} setHoveredCiv={setHoveredCiv} 
                         setHoveredUnit={setHoveredUnit} setHoveredBuilding={setHoveredBuilding} setSelectedCity={setSelectedCity} 
-                        civsById={civsById}/>
+                        declineViewCivsById={declineViewCivsById}/>
                     })}
             </>}
         </div>
@@ -325,7 +327,7 @@ const UpperRightDisplay = ({ mainGameState, canFoundCity, isFoundingCity, disabl
     templates,
     setConfirmEnterDecline, setTechChoiceDialogOpen, setHoveredUnit, setHoveredBuilding, setHoveredTech, 
     toggleFoundingCity, myCiv, myGamePlayer, myCities, setTechListDialogOpen, 
-    turnNum, setDeclineOptionsView, declineViewGameState, setSelectedCity, setHoveredCiv, setHoveredWonder, civsById}) => {
+    turnNum, setDeclineOptionsView, declineViewGameState, setSelectedCity, setHoveredCiv, setHoveredWonder, civsById, declineViewCivsById}) => {
     return (
         <div className="upper-right-display">
             {myCiv && <WonderListDisplay wonders_by_age={mainGameState.wonders_by_age} game_age={mainGameState.advancement_level} built_wonders={mainGameState.built_wonders} cost_by_age={mainGameState.wonder_cost_by_age} templates={templates} setHoveredWonder={setHoveredWonder}/>}
@@ -335,7 +337,7 @@ const UpperRightDisplay = ({ mainGameState, canFoundCity, isFoundingCity, disabl
                 disableUI={disableUI} centerMap={centerMap} declineOptionsView={declineOptionsView} setDeclineOptionsView={setDeclineOptionsView} 
                 declineViewGameState={declineViewGameState} mainGameState={mainGameState} templates={templates}
                 setSelectedCity={setSelectedCity} setHoveredCiv={setHoveredCiv} setHoveredUnit={setHoveredUnit} setHoveredBuilding={setHoveredBuilding}
-                civsById={civsById}/>}
+                declineViewCivsById={declineViewCivsById}/>}
             {myGamePlayer?.score > 0 && <ScoreDisplay myGamePlayer={myGamePlayer} gameEndScore={mainGameState.game_end_score} gameState={mainGameState}/>}
         </div>
     );

--- a/game_state.py
+++ b/game_state.py
@@ -190,16 +190,16 @@ def make_game_statistics_plots(sess, game_id: str):
             if yields_by_civ[civ_id] == 0 and total_metal_value_by_civ[civ_id] == 0 and civ_id not in dead_turns:
                 dead_turns[civ_id] = frame.turn_num
 
-        def civ_color(hex) -> str | None:
+        def civ_color(hex: Hex) -> str | None:
             if hex.city:
-                return hex.city.civ_id
+                return hex.city.civ.id
            
-            neighbor_city_civs = {n.city.civ_id for n in hex.get_neighbors(game_state.hexes) if n.city}
+            neighbor_city_civs = {n.city.civ.id for n in hex.get_neighbors(game_state.hexes) if n.city}
             if len(neighbor_city_civs) == 1:
                 return neighbor_city_civs.pop()
             if len(neighbor_city_civs) > 1:
-                if len(hex.units) > 0 and hex.units[0].civ_id in neighbor_city_civs:
-                    return hex.units[0].civ_id
+                if len(hex.units) > 0 and hex.units[0].civ.id in neighbor_city_civs:
+                    return hex.units[0].civ.id
 
             return None
 

--- a/game_state.py
+++ b/game_state.py
@@ -1187,7 +1187,7 @@ class GameState:
                 return civ
         raise Exception(f"Civ not found: {civ_name}, {self.civs_by_id}")
     
-    def to_json(self, from_civ_perspectives: Optional[list[Civ]] = None, include_city_civ_details: bool = False) -> dict:
+    def to_json(self, from_civ_perspectives: Optional[list[Civ]] = None) -> dict:
         if self.game_over:
             from_civ_perspectives = None
 
@@ -1195,7 +1195,7 @@ class GameState:
             "game_id": self.game_id,
             "hexes": {key: hex.to_json(from_civ_perspectives=from_civ_perspectives) for key, hex in self.hexes.items()},
             "civs_by_id": {civ_id: civ.to_json() for civ_id, civ in self.civs_by_id.items()},
-            "cities_by_id": {city_id: city.to_json(include_civ_details=include_city_civ_details) for city_id, city in self.cities_by_id.items()},
+            "cities_by_id": {city_id: city.to_json() for city_id, city in self.cities_by_id.items()},
             "game_player_by_player_num": {player_num: game_player.to_json() for player_num, game_player in self.game_player_by_player_num.items()},
             "turn_num": self.turn_num,
             "wonders_by_age": {age: [wonder.name for wonder in wonders] for age, wonders in self.wonders_by_age.items()},

--- a/game_state.py
+++ b/game_state.py
@@ -301,8 +301,8 @@ class GameState:
         city.midturn_update(self)
         return city
 
-    def register_camp(self, camp, hex):
-        camp.hex = hex
+    def register_camp(self, camp: 'Camp', hex: 'Hex'):
+        camp.set_hex(hex)
         hex.camp = camp
         self.camps.append(camp)
 

--- a/game_state.py
+++ b/game_state.py
@@ -931,8 +931,9 @@ class GameState:
         units_copy = self.units[:]
         random.shuffle(units_copy)
         for unit in units_copy:
-            unit.move(sess, self)
-            unit.attack(sess, self)
+            if not unit.dead:
+                unit.move(sess, self)
+                unit.attack(sess, self)
 
         print("moving units 1: commit")
         sess.commit()

--- a/hex.py
+++ b/hex.py
@@ -145,7 +145,7 @@ class Hex:
             game_state.cities_by_id[self.city.id] = self.city
         if self.camp:
             self.camp.update_civ_by_id(game_state.civs_by_id)          
-            self.camp.hex = self
+            self.camp.set_hex(self)
 
     def to_json(self, from_civ_perspectives: Optional[list[Civ]] = None) -> dict:
         result = {

--- a/hex.py
+++ b/hex.py
@@ -141,7 +141,7 @@ class Hex:
             # game_state.units.append(unit)
         if self.city:
             self.city.update_civ_by_id(game_state.civs_by_id)
-            self.city.hex = self
+            self.city.set_hex(self)
             game_state.cities_by_id[self.city.id] = self.city
         if self.camp:
             self.camp.update_civ_by_id(game_state.civs_by_id)          

--- a/hex.py
+++ b/hex.py
@@ -100,9 +100,11 @@ class Hex:
         ], hexes)
 
     def get_hexes_within_range(self, hexes: dict[str, "Hex"], range: int) -> Generator["Hex", None, None]:
-        assert range > 0 and range <= 3
+        assert range >= 0 and range <= 3, f"Range must be between 1 and 3, got {range}"
+        if range >= 0:
+            yield self
         if range >= 1:
-            yield from self.get_neighbors(hexes, include_self=True)
+            yield from self.get_neighbors(hexes, include_self=False)
         if range >= 2:
             yield from self.get_distance_2_hexes(hexes)
         if range >= 3:
@@ -132,20 +134,6 @@ class Hex:
             if hex.units and hex.units[0].civ.id != self.city.civ.id:
                 return True
         return False
-
-    def from_json_postprocess(self, game_state: 'GameState') -> None:
-        for unit in self.units:
-            unit.finish_loading_civ(game_state.civs_by_id)
-            unit.finish_loading_hex(self)
-            # Don't append here; they got added in GameState.init
-            # game_state.units.append(unit)
-        if self.city:
-            self.city.finish_loading_civ(game_state.civs_by_id)
-            self.city.finish_loading_hex(self)
-            game_state.cities_by_id[self.city.id] = self.city
-        if self.camp:
-            self.camp.finish_loading_civ(game_state.civs_by_id)          
-            self.camp.finish_loading_hex(self)
 
     def to_json(self, from_civ_perspectives: Optional[list[Civ]] = None) -> dict:
         result = {

--- a/hex.py
+++ b/hex.py
@@ -136,7 +136,7 @@ class Hex:
     def from_json_postprocess(self, game_state: 'GameState') -> None:
         for unit in self.units:
             unit.update_civ_by_id(game_state.civs_by_id)
-            unit.hex = self
+            unit.set_hex(self)
             # Don't append here; they got added in GameState.init
             # game_state.units.append(unit)
         if self.city:

--- a/hex.py
+++ b/hex.py
@@ -135,17 +135,17 @@ class Hex:
 
     def from_json_postprocess(self, game_state: 'GameState') -> None:
         for unit in self.units:
-            unit.update_civ_by_id(game_state.civs_by_id)
-            unit.set_hex(self)
+            unit.finish_loading_civ(game_state.civs_by_id)
+            unit.finish_loading_hex(self)
             # Don't append here; they got added in GameState.init
             # game_state.units.append(unit)
         if self.city:
-            self.city.update_civ_by_id(game_state.civs_by_id)
-            self.city.set_hex(self)
+            self.city.finish_loading_civ(game_state.civs_by_id)
+            self.city.finish_loading_hex(self)
             game_state.cities_by_id[self.city.id] = self.city
         if self.camp:
-            self.camp.update_civ_by_id(game_state.civs_by_id)          
-            self.camp.set_hex(self)
+            self.camp.finish_loading_civ(game_state.civs_by_id)          
+            self.camp.finish_loading_hex(self)
 
     def to_json(self, from_civ_perspectives: Optional[list[Civ]] = None) -> dict:
         result = {

--- a/map_object.py
+++ b/map_object.py
@@ -5,8 +5,6 @@ if TYPE_CHECKING:
     from civ import Civ
     from game_state import GameState
     from hex import Hex
-    from unit import Unit
-    from unit_template import UnitTemplate
 
 class MapObject(abc.ABC):
     def __init__(self, civ: 'Civ | None' = None, hex: 'Hex | None' = None):
@@ -92,37 +90,6 @@ class MapObject(abc.ABC):
         if self.no_cities_adjacent_range is not None:
             for hex in self.hex.get_hexes_within_range(hexes, self.no_cities_adjacent_range):
                 hex.is_foundable_by_civ[self.civ.id] = False
-
-    def spawn_unit_on_hex(self, game_state: 'GameState', unit_template: 'UnitTemplate', hex: 'Hex', bonus_strength: int=0, stack_size=1) -> 'Unit | None':
-        from unit import Unit
-        unit = Unit(unit_template, civ=self.civ, hex=hex)
-        unit.health *= stack_size
-        hex.units.append(unit)
-        game_state.units.append(unit)
-        unit.strength += bonus_strength
-
-        return unit
-
-    def get_siege_state(self, game_state: 'GameState') -> 'Civ | None':
-        for unit in self.hex.units:
-            if unit.civ.id != self.civ.id and unit.template.type == 'military':
-                return unit.civ
-        return None
-
-    def handle_siege(self, sess, game_state: 'GameState') -> None:
-        siege_state = self.get_siege_state(game_state)
-
-        if self.under_siege_by_civ is None:
-            self.under_siege_by_civ = siege_state
-        else:
-            if siege_state is None or siege_state.id != self.under_siege_by_civ.id:
-                self.under_siege_by_civ = siege_state
-            else:
-                self.capture(sess, siege_state, game_state)
-
-    @abc.abstractmethod
-    def capture(self, sess, siege_state: 'Civ', game_state: 'GameState') -> None:
-        pass
 
     def to_json(self):
         return {

--- a/map_object.py
+++ b/map_object.py
@@ -1,0 +1,23 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from civ import Civ
+    from hex import Hex
+
+class MapObject:
+    def __init__(self):
+        self._hex: 'Hex | None' = None
+        self._civ: 'Civ | None' = None
+
+    @property
+    def hex(self) -> 'Hex':
+        assert self._hex is not None
+        return self._hex
+    
+    def set_hex(self, hex: 'Hex'):
+        assert self._hex is None
+        self._hex = hex
+
+    def update_hex(self, hex: 'Hex'):
+        assert self._hex is not None
+        self._hex = hex

--- a/map_object.py
+++ b/map_object.py
@@ -1,10 +1,12 @@
+import abc
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from civ import Civ
+    from game_state import GameState
     from hex import Hex
 
-class MapObject:
+class MapObject(abc.ABC):
     def __init__(self, civ: 'Civ | None' = None, hex: 'Hex | None' = None):
         self._hex: 'Hex | None' = hex
         self._partially_loaded_hex_coords: str | None = None
@@ -16,8 +18,10 @@ class MapObject:
         assert self._hex is not None
         return self._hex
     
-    def finish_loading_hex(self, hex: 'Hex'):
-        assert self._hex is None and hex.coords == self._partially_loaded_hex_coords, f"hex coords {hex.coords} != {self._partially_loaded_hex_coords}"
+    def _finish_loading_hex(self, hexes: dict[str, 'Hex']):
+        assert self._partially_loaded_hex_coords is not None and self._hex is None
+        hex = hexes[self._partially_loaded_hex_coords]
+        assert hex.coords == self._partially_loaded_hex_coords, f"hex coords {hex.coords} != {self._partially_loaded_hex_coords}"
         self._hex = hex
         self._partially_loaded_hex_coords = None
 
@@ -30,7 +34,7 @@ class MapObject:
         assert self._civ is not None
         return self._civ
     
-    def finish_loading_civ(self, civs_by_id: dict[str, 'Civ']) -> None:
+    def _finish_loading_civ(self, civs_by_id: dict[str, 'Civ']) -> None:
         assert self._partially_loaded_civ_id is not None and self._civ is None
         self._civ = civs_by_id[self._partially_loaded_civ_id]
         self._partially_loaded_civ_id = None
@@ -38,7 +42,55 @@ class MapObject:
     def update_civ(self, civ: 'Civ'):
         assert self._civ is not None
         self._civ = civ
+
+    def from_json_postprocess(self, game_state: 'GameState') -> None:
+        self._finish_loading_civ(game_state.civs_by_id)
+        self._finish_loading_hex(game_state.hexes)
+
+    def get_closest_target(self) -> 'Hex | None':
+        target1 = self.civ.target1
+        target2 = self.civ.target2
+
+        if target1 is None and target2 is None:
+            return None
+        
+        if target1 is None:
+            return target2
+        
+        if target2 is None:
+            return target1
+        
+        if self.hex.distance_to(target1) <= self.hex.distance_to(target2):
+            return target1
+        else:
+            return target2
+
+    def sight_range(self, short_sighted: bool) -> int:
+        return 2 if short_sighted else 1
     
+    @property
+    def no_cities_adjacent_range(self) -> int | None:
+        return None
+
+    def update_nearby_hexes_visibility(self, game_state: 'GameState', short_sighted: bool = False) -> None:
+        range = self.sight_range(short_sighted)
+        neighbors = self.hex.get_hexes_within_range(game_state.hexes, range)
+
+        for nearby_hex in neighbors:
+            nearby_hex.visibility_by_civ[self.civ.id] = True
+
+    def update_nearby_hexes_hostile_foundability(self, hexes: dict[str, 'Hex']) -> None:
+        # No one can make cities adjacent to an enemy MapObject.
+        for hex in self.hex.get_neighbors(hexes, include_self=True):
+            for key in hex.is_foundable_by_civ:
+                if key != self.civ.id:
+                    hex.is_foundable_by_civ[key] = False
+
+        # Even myself can't make cities within no_cities_adjacent_range
+        if self.no_cities_adjacent_range is not None:
+            for hex in self.hex.get_hexes_within_range(hexes, self.no_cities_adjacent_range):
+                hex.is_foundable_by_civ[self.civ.id] = False
+
     def to_json(self):
         return {
             "hex": self.hex.coords,

--- a/map_object.py
+++ b/map_object.py
@@ -5,6 +5,8 @@ if TYPE_CHECKING:
     from civ import Civ
     from game_state import GameState
     from hex import Hex
+    from unit import Unit
+    from unit_template import UnitTemplate
 
 class MapObject(abc.ABC):
     def __init__(self, civ: 'Civ | None' = None, hex: 'Hex | None' = None):
@@ -90,6 +92,37 @@ class MapObject(abc.ABC):
         if self.no_cities_adjacent_range is not None:
             for hex in self.hex.get_hexes_within_range(hexes, self.no_cities_adjacent_range):
                 hex.is_foundable_by_civ[self.civ.id] = False
+
+    def spawn_unit_on_hex(self, game_state: 'GameState', unit_template: 'UnitTemplate', hex: 'Hex', bonus_strength: int=0, stack_size=1) -> 'Unit | None':
+        from unit import Unit
+        unit = Unit(unit_template, civ=self.civ, hex=hex)
+        unit.health *= stack_size
+        hex.units.append(unit)
+        game_state.units.append(unit)
+        unit.strength += bonus_strength
+
+        return unit
+
+    def get_siege_state(self, game_state: 'GameState') -> 'Civ | None':
+        for unit in self.hex.units:
+            if unit.civ.id != self.civ.id and unit.template.type == 'military':
+                return unit.civ
+        return None
+
+    def handle_siege(self, sess, game_state: 'GameState') -> None:
+        siege_state = self.get_siege_state(game_state)
+
+        if self.under_siege_by_civ is None:
+            self.under_siege_by_civ = siege_state
+        else:
+            if siege_state is None or siege_state.id != self.under_siege_by_civ.id:
+                self.under_siege_by_civ = siege_state
+            else:
+                self.capture(sess, siege_state, game_state)
+
+    @abc.abstractmethod
+    def capture(self, sess, siege_state: 'Civ', game_state: 'GameState') -> None:
+        pass
 
     def to_json(self):
         return {

--- a/map_object.py
+++ b/map_object.py
@@ -5,19 +5,46 @@ if TYPE_CHECKING:
     from hex import Hex
 
 class MapObject:
-    def __init__(self):
-        self._hex: 'Hex | None' = None
-        self._civ: 'Civ | None' = None
+    def __init__(self, civ: 'Civ | None' = None, hex: 'Hex | None' = None):
+        self._hex: 'Hex | None' = hex
+        self._partially_loaded_hex_coords: str | None = None
+        self._civ: 'Civ | None' = civ
+        self._partially_loaded_civ_id: str | None = None
 
     @property
     def hex(self) -> 'Hex':
         assert self._hex is not None
         return self._hex
     
-    def set_hex(self, hex: 'Hex'):
-        assert self._hex is None
+    def finish_loading_hex(self, hex: 'Hex'):
+        assert self._hex is None and hex.coords == self._partially_loaded_hex_coords, f"hex coords {hex.coords} != {self._partially_loaded_hex_coords}"
         self._hex = hex
+        self._partially_loaded_hex_coords = None
 
     def update_hex(self, hex: 'Hex'):
         assert self._hex is not None
         self._hex = hex
+
+    @property
+    def civ(self) -> 'Civ':
+        assert self._civ is not None
+        return self._civ
+    
+    def finish_loading_civ(self, civs_by_id: dict[str, 'Civ']) -> None:
+        assert self._partially_loaded_civ_id is not None and self._civ is None
+        self._civ = civs_by_id[self._partially_loaded_civ_id]
+        self._partially_loaded_civ_id = None
+
+    def update_civ(self, civ: 'Civ'):
+        assert self._civ is not None
+        self._civ = civ
+    
+    def to_json(self):
+        return {
+            "hex": self.hex.coords,
+            "civ_id": self.civ.id,
+        }
+    
+    def from_json(self, json):
+        self._partially_loaded_civ_id = json["civ_id"]
+        self._partially_loaded_hex_coords = json["hex"]

--- a/map_object_spawner.py
+++ b/map_object_spawner.py
@@ -1,0 +1,66 @@
+import abc
+from typing import TYPE_CHECKING
+
+from map_object import MapObject
+from unit import Unit
+
+if TYPE_CHECKING:
+    from civ import Civ
+    from hex import Hex
+    from game_state import GameState
+    from unit_template import UnitTemplate
+
+class MapObjectSpawner(MapObject):
+    def __init__(self, civ: 'Civ | None', hex: 'Hex | None'):
+        super().__init__(civ, hex)
+        self.under_siege_by_civ: 'Civ | None' = None
+        self._partially_loaded_under_siege_by_civ_id: str | None = None
+
+    def _finish_loading_under_siege_by_civ(self, civs_by_id: dict[str, 'Civ']) -> None:
+        assert self.under_siege_by_civ is None
+        if self._partially_loaded_under_siege_by_civ_id is not None:
+            self.under_siege_by_civ = civs_by_id[self._partially_loaded_under_siege_by_civ_id]
+            self._partially_loaded_under_siege_by_civ_id = None
+
+    def spawn_unit_on_hex(self, game_state: 'GameState', unit_template: 'UnitTemplate', hex: 'Hex', bonus_strength: int=0, stack_size=1) -> 'Unit | None':
+        unit = Unit(unit_template, civ=self.civ, hex=hex)
+        unit.health *= stack_size
+        hex.units.append(unit)
+        game_state.units.append(unit)
+        unit.strength += bonus_strength
+        return unit
+
+    def get_siege_state(self, game_state: 'GameState') -> 'Civ | None':
+        for unit in self.hex.units:
+            if unit.civ.id != self.civ.id and unit.template.type == 'military':
+                return unit.civ
+        return None
+
+    def handle_siege(self, sess, game_state: 'GameState') -> None:
+        siege_state = self.get_siege_state(game_state)
+
+        if self.under_siege_by_civ is None:
+            self.under_siege_by_civ = siege_state
+        else:
+            if siege_state is None or siege_state.id != self.under_siege_by_civ.id:
+                self.under_siege_by_civ = siege_state
+            else:
+                self.capture(sess, siege_state, game_state)
+
+    @abc.abstractmethod
+    def capture(self, sess, siege_state: 'Civ', game_state: 'GameState') -> None:
+        pass
+
+    def from_json_postprocess(self, game_state: 'GameState') -> None:
+        super().from_json_postprocess(game_state)
+        self._finish_loading_under_siege_by_civ(game_state.civs_by_id)
+
+    def to_json(self):
+        return {
+            **super().to_json(),
+            "under_siege_by_civ_id": self.under_siege_by_civ.id if self.under_siege_by_civ is not None else None
+        }
+    
+    def from_json(self, json):
+        super().from_json(json)
+        self._partially_loaded_under_siege_by_civ_id = json["under_siege_by_civ_id"]

--- a/unit.py
+++ b/unit.py
@@ -257,14 +257,14 @@ class Unit:
         af_bonus = 0
         af_city = None
         for city in self.civ.get_my_cities(game_state):
-            assert city.hex is not None and battle_location is not None
+            assert battle_location is not None
             for ability, _ in city.passive_building_abilities_of_name('Airforce'):
                 if city.hex.distance_to(battle_location) <= ability.numbers[1]:
                     af_bonus = max(af_bonus, ability.numbers[0])
                     af_city = city
 
         if af_city is not None:
-            assert af_city.hex is not None and self.hex is not None
+            assert self.hex is not None
             support_hexes.add((af_city.hex, self.hex))
 
         return bonus_strength + af_bonus

--- a/unit.py
+++ b/unit.py
@@ -2,6 +2,7 @@ from math import ceil
 import random
 from typing import TYPE_CHECKING, Generator, Optional
 from civ import Civ
+from map_object import MapObject
 from wonder_templates_list import WONDERS
 from settings import UNIT_KILL_REWARD, DAMAGE_DOUBLE_EXPONENT, DAMAGE_EQUAL_STR
 from unit_template import UnitTemplate, UnitTag
@@ -13,29 +14,20 @@ if TYPE_CHECKING:
     from hex import Hex
 
 
-class Unit:
+class Unit(MapObject):
     def __init__(self, template: UnitTemplate, civ: Civ) -> None:
         # civ actually can be None very briefly before GameState.from_json() is done, 
         # but I don't want to tell the type-checker so we don't have to put a million asserts everywhere
-
+        super().__init__()
         self.id = generate_unique_id()
         self.template = template
         self.health = 100
         self.civ = civ
         self.civ_id: str = civ.id if civ else None  # type: ignore
         self.has_moved = False
-        self._hex: Optional['Hex'] = None
         self.strength = self.template.strength
         self.attacks_used = 0
         self.destination = None
-
-    @property
-    def hex(self):
-        assert self._hex is not None
-        return self._hex
-    
-    def set_hex(self, hex: 'Hex'):
-        self._hex = hex
 
     @property
     def dead(self):
@@ -421,7 +413,7 @@ class Unit:
 
     def take_one_step_to_hex(self, hex: 'Hex') -> None:
         self.hex.remove_unit(self)
-        self.set_hex(hex)
+        self.update_hex(hex)
         hex.units.append(self)
 
     def turn_end(self, game_state: 'GameState') -> None:

--- a/unit.py
+++ b/unit.py
@@ -399,6 +399,9 @@ class Unit(MapObject):
     def update_nearby_hexes_friendly_foundability(self) -> None:
         self.hex.is_foundable_by_civ[self.civ.id] = True
 
+    def capture(self, sess, game_state: 'GameState') -> None:
+        raise ValueError(f"Somehow a unit got sieged and captured. That should only happen to cities and camps. {self.id=} {self.template.name=} {self.hex.coords=}")
+
     def to_json(self) -> dict:
         return {
             **super().to_json(),


### PR DESCRIPTION
This removes a bunch of duplicated code by adding base class MapObject and MapObjectSpawner for units, camps, and cities to share code.

Pros: 
* Never have to bother wtih `assert self.hex is not None` again.
* it means code will stay in sync more

Cons:
* The number of instances of `super().__init__` in our code goes way up.